### PR TITLE
Adding DevOps

### DIFF
--- a/Web Development/README.md
+++ b/Web Development/README.md
@@ -13,10 +13,10 @@
 
 - [Tutorials or Courses](#tutorials-or-courses)
 
-  - [Front-End Development](#front-end-development)
+  - [Front-End Development](#front-end-development-1)
   - [Back-End Development](#backend-development)
-  - [DevOps](#devOps)
-  - [Full-Stack Development](#full-stack-development)
+  - [DevOps](#devops-1)
+  - [Full-Stack Development](#full-stack-development-1)
 
 - [Tools](#tools)<br>
   - [Typography](#typography)

--- a/Web Development/README.md
+++ b/Web Development/README.md
@@ -7,13 +7,15 @@
 - [Roadmap](roadmaps)
 
   - [Front-End Development Roadmap](#front-end-development)
-  - [Back-End Development Roadmap](#backend-development)
+  - [Back-End Development Roadmap](#back-end-development)
+  - [DevOps Roadmap](#devOps)
   - [Full-Stack Development Roadmap](#full-stack-development)
 
 - [Tutorials or Courses](#tutorials-or-courses)
 
   - [Front-End Development](#front-end-development)
   - [Back-End Development](#backend-development)
+  - [DevOps](#devOps)
   - [Full-Stack Development](#full-stack-development)
 
 - [Tools](#tools)<br>
@@ -70,6 +72,19 @@ This category is a curated collection of valuable web development resources cont
 <tr>
    <td><a href="https://roadmap.sh/backend">Backend</a></td>
    <td>This is the roadmap for backend development</td>
+</tr>
+</table>
+
+#### DevOps
+
+<table width="100%">
+    <tr>
+    <th>Resource Name</th>
+    <th>Description</th>
+  </tr>
+<tr>
+   <td><a href="https://roadmap.sh/devops">DevOps</a></td>
+   <td>This is the roadmap for Devops</td>
 </tr>
 </table>
 
@@ -286,6 +301,92 @@ Fortunately, Spring Boot provides seamless integration with JSON Web Tokens (JWT
       <td><a href="https://www.freecodecamp.org/learn/back-end-development-and-apis/">Back End Development and APIs</a></td>
       <td>In the Back End Development and APIs Certification, you'll learn to build back end applications using Node.js and npm, create web applications with the Express framework, and develop a People Finder microservice using MongoDB and the Mongoose library.<
   </tr>
+</table>
+
+### DevOps
+
+<table width="100%">
+    <tr>
+        <th>Resource Name</th>
+        <th>Description</th>
+    </tr>
+    <tr>
+        <td><a href="https://youtu.be/Xrgk023l4lI?si=PcUEOaYkjPvX0vUz">Overview of DevOps</a></td>
+        <td>A short yet concise and helpful video about DevOps from scratch.</td>
+    </tr>
+  <tr>
+      <td><a href="https://youtu.be/Fi3_BjVzpqk?si=V5uWKwaX3VSm9Taq">Basics of SDLC</a></td>
+      <td>Understand how is a software created and where do “DevOps” fall in Software Development Life Cycle. SDLC, or Software Development Life Cycle, is the step-by-step process that software goes through, from planning and coding to testing and deployment.</td>
+  </tr>
+  <tr>
+      <td><a href="https://youtu.be/sWbUDq4S6Y8?si=JDafpN0J7BeTNZu0">Operating System (Linux) </a></td>
+      <td>Linux is the go-to choice for servers, and Most DevOps tools are Linux-based; so  knowing linux commands helps a lot in server management and handling Devops Tasks. </td>
+  </tr>
+  <tr>
+      <td><a href="https://cheatography.com/davechild/cheat-sheets/linux-command-line/">Linux CheatSheet</a></td>
+      <td>A cheat sheet of all Linux Commands</td>
+  </tr>
+  <tr>
+      <td><a href="https://youtube.com/playlist?list=PLAdTNzDIZj_-3uxvcoF5bsx_MEHXSFgN5&si=4odsNpdA0NUH79mz">Programming(Python)</a></td>
+      <td>30 Days of Python for DevOps. This playlist contain skills and technologies that any DevOps engineer working with Python should know.</td>
+  </tr>
+  <tr>
+      <td><a href="https://git-scm.com/book/en/v2">Git for Version Control</a></td>
+      <td>Exploring Version Control in DevOps for Modern Software Development. Git is Important to work as DevOps engineer</td>
+  </tr>
+  <tr>
+      <td><a href="https://youtu.be/IPvYjXCsTg8?si=3pXsVhOA_s7OEur2">Networking & Security</a></td>
+      <td>Networking fundamentals for DevOps Engineer-fundamentals of networking, OSI model deep dive, networking protocols, devices, tools, and more with real-life examples.s</td>
+  </tr>
+  <tr>
+      <td><a href="https://youtu.be/B8i49C8fC3E?si=WETBYRhuRkGxJl47">Amazon Web Services(AWS)</a></td>
+      <td>This tutorial contains information about AWS services for DevOps and a walkthrough you can use to experiment with those services.</td>
+  </tr>
+  <tr>
+      <td><a href="https://aws.amazon.com/devops/resources/">AWS Documentation</a></td>
+      <td>This is the official documenatation of AWS which have collection of free videos and labs to help you get you started with DevOps services.</td>
+  </tr>
+  <tr>
+      <td><a href="https://www.youtube.com/live/7Hww8PPHHE0?si=b0ezlKO0qoRJ_mb_">Microsoft Azure</a></td>
+      <td>This Azure Tutorial is ideal for both beginners as well as professionals who want to master Azure services. Azure DevOps provides an integrated set of services and tools to manage your software projects, from planning and development through testing and deployment. Azure DevOps delivers services through a client/server model.</td>
+  </tr>
+  <tr>
+      <td><a href="https://youtu.be/KFtNEtsvsgw?si=Nc2MbiIbUmkkiWe4">Infrastructure as Code (IAC)</a></td>
+      <td>Infrastructure as Code (IaC) is the managing and provisioning of infrastructure through code instead of through manual processes. So, Infrastructure as Code or IaC is a concept and there are Infrastructure as Code tools, like Ansible, Puppet, Terraform or Cloudformation etc  that you can use for different tasks.</td>
+  </tr>
+  <tr>
+      <td><a href="https://avinetworks.com/what-are-microservices-and-containers/">Microservices and Containerization</a></td>
+      <td>Microservices is the new way to deploy applications independently for better scaling and management, and they are packaged in a container.Container: A packaged application with its dependencies, isolated for easy deployment, and capable of running consistently on any machine.</td>
+  </tr>
+  <tr>
+      <td><a href="https://youtu.be/rr9cI4u1_88?si=Vf6YWyIGtHq47p9l">Docker Tutorial with Project</a></td>
+      <td>Docker is a containerization platform that allows you to package your application and all of its dependencies together. It's a great way to deploy your application in a consistent environment, regardless of the underlying infrastructure.</td>
+  </tr>
+  <tr>
+      <td><a href="https://docs.docker.com/">Docker Documentation</a></td>
+      <td>The official Documentation of Docker, where you can learn how to install Docker for Mac, Windows, or Linux and explore the developer tools as well.</td>
+  </tr>
+  <tr>
+      <td><a href="https://youtu.be/hJw8Sy13Vp8?si=8g-tTduvKYITJwav">Container Orchestration (Kubernetes)</a></td>
+      <td>When using microservices an application can have hundreds or thousands of containers on multiple servers. Managing, scaling and other operations for these containers require container orchestration tools like Kubernetes.</td>
+  </tr>
+  <tr>
+      <td><a href="https://about.gitlab.com/topics/ci-cd/">CI/CD Pipelines</a></td>
+      <td>A pipeline is a process that drives software development through a path of building, testing, and deploying code, also known as CI/CD.</td>
+  </tr>
+  <tr>
+      <td><a href="https://youtu.be/6YZvp2GwT0A?si=k_3lhSr_POESCIRB">Jenkins</a></td>
+      <td>Jenkins is an open source automation server which enables you to reliably build, test, and deploy your software. It is one of the most sought over skills for a DevOps Engineer to have.</td>
+  </tr>
+  <tr>
+      <td><a href="https://youtu.be/aljzrNEqNDw?si=TFVcnnCeN98WZ9Xk">Monitoring and Logging</a></td>
+      <td>Once the software is released you need to continuosly monitor it to track performance and discover problems</td>
+  </tr>
+  <tr>
+      <td><a href="https://about.gitlab.com/topics/gitops/">Gitops</a></td>
+      <td>GitOps is a development methodology that leverages Git repositories as the single source of truth for both infrastructure and application code. Basically, it involves using Git to manage and automate the entire software delivery process, from version control to deployment.</td>
+  </tr>
+  
 </table>
 
 <table width="100%">

--- a/Web Development/README.md
+++ b/Web Development/README.md
@@ -8,7 +8,7 @@
 
   - [Front-End Development Roadmap](#front-end-development)
   - [Back-End Development Roadmap](#back-end-development)
-  - [DevOps Roadmap](#devOps)
+  - [DevOps Roadmap](#devops)
   - [Full-Stack Development Roadmap](#full-stack-development)
 
 - [Tutorials or Courses](#tutorials-or-courses)


### PR DESCRIPTION
### Fixes Issue #199 

### Description: 
I've added roadmap, courses and tutorials related to DevOps and linking the headings to the resources section,  where clicking on a heading under the tutorials and courses section scrolls directly to the resources of the clicked heading. 


### Changes: 
  - Added the DevOps Section and all other resources related to it.
  - Added direct scroll to resources on heading click.
  

### Testing:
I've tested the changes locally to ensure they display correctly and function as intended.

### Screenshot:
![DevOps](https://github.com/jfmartinz/ResourceHub/assets/142304973/fd95c68f-f91e-408d-93ee-6893f978dca4)

### Checklist:
Before submitting your pull request, ensure that you have completed the following tasks: 

- [x] I have carefully reviewed and adhered to the [contributing guidelines](https://github.com/jfmartinz/ResourceHub/blob/main/CONTRIBUTING.md) before creating this pull request.
- [x] I followed the prescribed PR title template. 


@jfmartinz, Please review my PR.
