### PR TITLE
Overview tag removed and brought under the domain names

### DIFF
--- a/DBMS (Database)/README.md
+++ b/DBMS (Database)/README.md
@@ -1,16 +1,13 @@
 # Database
 
+A database is an organized collection of structured information, or data, typically stored electronically in a computer system. Databases are designed to make it easy to store, retrieve, manage, and update data efficiently.
+
 ## Table of Contents
 
-- [Overview](#overview)
 - [Database Category](#database-category)
   - [SQL Databases](#sql-databases)
   - [NoSQL Databases](#nosql-databases)
 - [Tutorial or Courses](#tutorial-or-courses)
-
-
-### Overview
-A database is an organized collection of structured information, or data, typically stored electronically in a computer system. Databases are designed to make it easy to store, retrieve, manage, and update data efficiently.
 
 
 ### Database Category

--- a/Open Source Development/README.MD
+++ b/Open Source Development/README.MD
@@ -1,16 +1,13 @@
 # Open Source Development 🌈
+Open source development involves collaborative creation of software where the source code is freely available for anyone to view, modify, and distribute. It fosters transparency, innovation, and community-driven improvement. Developers globally contribute code, fix bugs, and suggest enhancements, often through platforms like GitHub. Projects range from small utilities to complex systems like Linux and Apache. Open source encourages diversity, enabling developers from diverse backgrounds to participate and learn. It democratizes technology, offering accessible solutions and empowering users to tailor software to their needs while promoting a culture of sharing and cooperation in the tech community.
 
 ## Table of Contents
-- [Overview](#overview)<br>
 - [Website to learn Open Source Development](#website-to-learn-open-source-development)<br>
 - [Tutorial or Courses](#tutorial-or-courses)<br>
 - [Open Source Technologies](#open-source-technologies)<br>
 - [Community](#community)<br>
 - [Events](#events)<br>
 - [Youtube Channels](#youtube-channels)
-
-### Overview
-Open source development involves collaborative creation of software where the source code is freely available for anyone to view, modify, and distribute. It fosters transparency, innovation, and community-driven improvement. Developers globally contribute code, fix bugs, and suggest enhancements, often through platforms like GitHub. Projects range from small utilities to complex systems like Linux and Apache. Open source encourages diversity, enabling developers from diverse backgrounds to participate and learn. It democratizes technology, offering accessible solutions and empowering users to tailor software to their needs while promoting a culture of sharing and cooperation in the tech community.
 
 ### Website to learn Open Source Development
 <table width="100%">

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Here is a list of the currently available categories of the project:<br>
 - [UI & UX Design](https://github.com/jfmartinz/ResourceHub/tree/main/UI-UX%20Design)
 - [Web3](https://github.com/jfmartinz/ResourceHub/tree/main/Web3)
 - [Database](https://github.com/jfmartinz/ResourceHub/tree/main/DBMS%20(Database))
+- [Open Source Development](https://github.com/Nayanika1402/ResourceHub/tree/main/Open%20Source%20Development)
 
 
 ## How to contribute

--- a/UI-UX Design/README.md
+++ b/UI-UX Design/README.md
@@ -1,8 +1,8 @@
 # UI & UX Design 🎨
+This curated collection offers valuable UI (User Interface) and UX (User Experience) design resources contributed by talented individuals. Here, you'll discover a diverse range of materials and information on UI & UX design.
 
 ## Table of Contents
 
-- [Overview](#overview)<br>
 - [Tutorials or Courses](#tutorials-or-courses)<br>
 - [Roadmap](#Roadmap)<br>
 - [Tools](#tools)<br>
@@ -13,10 +13,6 @@
 - [Interview](#interview)<br>
 - [Newsletter](#newsletter)<br>
 - [UI/UX Design Challenges](#challenges)<br>
-
-### Overview
-
-This curated collection offers valuable UI (User Interface) and UX (User Experience) design resources contributed by talented individuals. Here, you'll discover a diverse range of materials and information on UI & UX design.
 
 ### Tutorials or Courses
 

--- a/Web Development/README.md
+++ b/Web Development/README.md
@@ -1,8 +1,7 @@
 # Web Development 🌐
+This category is a curated collection of valuable web development resources contributed by amazing contributors. Here, you will find a wide range of materials and information about web development.
 
 ## Table of Contents
-
-- [Overview](#overview)<br>
 
 - [Roadmap](roadmaps)
 
@@ -44,10 +43,6 @@
   - [Beginner level](#beginner-level-projects)
   - [Intermediate level](#intermediate-level-projects)
   - [Advanced level](#advance-level-projects)
-
-### Overview
-
-This category is a curated collection of valuable web development resources contributed by amazing contributors. Here, you will find a wide range of materials and information about web development.
 
 ### Roadmap
 

--- a/Web3/README.md
+++ b/Web3/README.md
@@ -1,7 +1,7 @@
 # Web3 🚀
+Web3 is the next-generation internet characterized by decentralization, blockchain technology, and user empowerment. It replaces central authorities with peer-to-peer interactions, relies on blockchain for trustless transactions, and emphasizes data ownership and privacy. Web3 features decentralized applications, smart contracts, and cryptocurrencies, fostering a more open, collaborative, and user-centric online ecosystem.
 
 ## Table of Contents
-- [Overview](#overview)<br>
 - [Website to learn web3](#website-to-learn-web3)<br>
 - [Tutorial or Courses](#tutorial-or-courses)<br>
 - [Blockchain Technologies](#blockchain-technologies)<br>
@@ -9,11 +9,6 @@
 - [Community](#community)<br>
 - [Youtube Channels](#youtube-channels)<br>
 - [Decentralized Finance (DeFi)](#decentralized-finance-defi)
-
-
-
-### Overview
-Web3 is the next-generation internet characterized by decentralization, blockchain technology, and user empowerment. It replaces central authorities with peer-to-peer interactions, relies on blockchain for trustless transactions, and emphasizes data ownership and privacy. Web3 features decentralized applications, smart contracts, and cryptocurrencies, fostering a more open, collaborative, and user-centric online ecosystem.
 
 ### Website to learn Web3
 <table width="100%">


### PR DESCRIPTION

### Fixes Issue:
Closes #240 


### Description: 
Overview section has been brought under the specific domain names and overview tag removed.

### Checklist:
Before submitting your pull request, ensure that you have completed the following tasks: 

- [ 🗸 ] I have carefully reviewed and adhered to the [contributing guidelines](https://github.com/jfmartinz/ResourceHub/blob/main/CONTRIBUTING.md) before creating this pull request.
- [ 🗸 ] I followed the prescribed PR title template. _(Check this if you're adding a resource)_

