### PR TITLE
Issue Reminders

### DIFF
--- a/.github/workflows/issue-reminder.yml
+++ b/.github/workflows/issue-reminder.yml
@@ -2,7 +2,7 @@ name: "Open-Issue-Reminder"
 
 on:
   schedule:
-    - cron: "* * * * *"
+    - cron: "0 12 */3 * *"
 
 jobs:
   welcome:

--- a/.github/workflows/issue-reminder.yml
+++ b/.github/workflows/issue-reminder.yml
@@ -1,33 +1,33 @@
-# name: "Open-Issue-Reminder"
+name: "Open-Issue-Reminder"
 
-# on:
-#   schedule:
-#     - cron: "* 12 */3 * *"
+on:
+  schedule:
+    - cron: "* * * * *"
 
-# jobs:
-#   welcome:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Checkout repository
-#         uses: actions/checkout@v2
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-#       - name: Run script
-#         uses: actions/github-script@v4
-#         with:
-#           github-token: ${{ secrets.GITHUB_TOKEN }}
-#           script: |
-#             const { data: issues } = await github.issues.listForRepo({
-#               owner: context.repo.owner,
-#               repo: context.repo.repo,
-#               state: 'open'
-#             });
-#             for (const issue of issues) {
-#               const issueComment = `Hi there! This issue is still open. We are for your response.
-#               Contributor Assigned: ${issue.assignees.map(assignee => '@' + assignee.login).join(', ') || 'None'}`;
-#               await github.issues.createComment({
-#                 issue_number: issue.number,
-#                 owner: context.repo.owner,
-#                 repo: context.repo.repo,
-#                 body: issueComment
-#               });
-#             }
+      - name: Run script
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: issues } = await github.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open'
+            });
+            for (const issue of issues) {
+              const issueComment = `Hi there! This issue is still open. We are waiting for your response.
+              Assignees: ${issue.assignees.map(assignee => '@' + assignee.login).join(', ') || 'None'}`;
+              await github.issues.createComment({
+                issue_number: issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: issueComment
+              });
+            }


### PR DESCRIPTION
Bugs Fixed in issue-reminder.yml
Previously Github Actions was sending reminder every minute which created some disturbances to contributors as well as Project Admin.

Now I have made the bot to only send a reminder once in 3 days that will reminder contributors about their pending open issues. 

### Checklist:

- [x ] I have carefully reviewed and adhered to the [contributing guidelines](https://github.com/jfmartinz/ResourceHub/blob/main/CONTRIBUTING.md) before creating this pull request.
- [ x] I followed the prescribed PR title template. _(Check this if you're adding a resource)_


