### PR TITLE
Add-Wagmi library in web 3

### DIFF
--- a/Web3/readme.md
+++ b/Web3/readme.md
@@ -368,6 +368,10 @@ develop software that works with them</td>
     <td>RainbowKit is a React library that makes it easy to add wallet connection to your dapp. It's intuitive, responsive and customizable.</td>
   </tr>
   <tr>
+    <td><a href="https://wagmi.sh/">Wagmi</a></td>
+    <td>Wagmi is a React Hooks library for Ethereum  Wagmi has a CLI to manage ABIs as well as a robust ecosystem of third-party libraries, RainbowKit, and many more, so you can get started quickly without needing to build everything from scratch.</td>
+  </tr>
+  <tr>
     <td><a href="https://web3py.readthedocs.io/en/stable/">Web3.py</a></td>
     <td>Web3.py is a Python library for interacting with the Ethereum blockchain. It provides a convenient interface for querying blockchain data, sending transactions, and deploying contracts using Python.</td>
   </tr>


### PR DESCRIPTION
- `Web 3 -  Blockchain Technologies [Librarie]


closes #807
### Description: 
>Wagmi is a React Hooks library for Ethereum  Wagmi has a CLI to manage ABIs as well as a robust ecosystem of third-party libraries, RainbowKit, and many more, so you can get started quickly without needing to build everything from scratch.

### Resource URL: 
>[Wagmi](https://wagmi.sh/)


### Checklist:

- [x] I have carefully reviewed and adhered to the [contributing guidelines](https://github.com/jfmartinz/ResourceHub/blob/main/CONTRIBUTING.md) before creating this pull request.
- [x] I followed the prescribed PR title template. _(Check this if you're adding a resource)_
Thanks
@jfmartinz  hope this is helpfull! 
