### PR TITLE
Django course links fixed

### DIFF
--- a/Programming Languages/Django/readme.md
+++ b/Programming Languages/Django/readme.md
@@ -325,13 +325,11 @@ Django is a high-level Python web framework that encourages rapid development an
     <td>A comprehensive tutorial on building a local library website with Django.</td>
   </tr>
   <tr>
-    <td><a href="
-  https://www.w3schools.com/django/index.php">w3schools - Learn Django</a></td>
+    <td><a href="https://www.w3schools.com/django/index.php">w3schools - Learn Django</a></td>
     <td>A comprehensive tutorial on Django.</td>
   </tr>
   <tr>
-    <td><a href="
-  https://www.tutorialspoint.com/django/index.htm">Tutorials Point- Django Tutorial</a></td>
+    <td><a href="https://www.tutorialspoint.com/django/index.htm">Tutorials Point- Django Tutorial</a></td>
     <td>Tutorials on Django.</td>
   </tr>
 </table>


### PR DESCRIPTION
# Pull Request

## Description
Please include a summary of the changes and the related issue.  
Django course links are now clickable

Closes # 

## Type of change
- [ ] Adding a new Resource
- [ ] Adding a new Category
- [X ] Documentation enhancement or fixes
- [ ] Website enhancement or fixes

## Checklist:
- [X ] I read carefully [CONTRIBUTING.md](https://github.com/jfmartinz/ResourceHub/blob/main/CONTRIBUTING.md)
- [X ] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] I have made corresponding changes to the documentation


## Screenshots (if appropriate):

Please add screenshots to help explain your changes.


## Additional 
