### PR TITLE
Added "Licensing Page" Reflecting "MIT Licence"

### DIFF
--- a/new-website/Licensing.html
+++ b/new-website/Licensing.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="assets/logo.png">
   <title>License</title>
-
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">  
   <style>
     body {
       font-family: Arial, sans-serif;
@@ -56,6 +56,14 @@
     header a {
       text-decoration: none;
     }
+    .home-link {
+    position: absolute;
+    top: 20px; 
+    left: 20px;
+    font-size: 24px;
+    color: #111210; 
+    text-decoration: none; 
+}
 
   </style>
 </head>
@@ -88,6 +96,9 @@
       SOFTWARE.</p>
   </div>
   </div>
+  <div class="col-md-10">
+    <a href="index.html" class="home-link"><i class="fas fa-arrow-left"> </i></a>
+</div>
 </body>
 
 </html>

--- a/new-website/Licensing.html
+++ b/new-website/Licensing.html
@@ -1,0 +1,318 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="assets/logo.png">
+    <title>License</title>
+
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #fff;
+            margin: 0;
+            padding: 0;
+        }
+
+        .container {
+            max-width: 800px;
+            margin: 30px auto;
+            padding: 20px;
+            background-color: #fff;
+            /* box-shadow: 0 0 10px rgba(0, 0, 0, 0.1); */
+            border-radius: 5px;
+        }
+
+        h1 {
+            /* text-align: center; */
+            font-size: 2em;
+            color: #333;
+            margin-bottom: 20px;
+        }
+
+        p {
+            font-size: 1.1em;
+            color: #555;
+            line-height: 1.6;
+        }
+
+        p+p {
+            margin-top: 20px;
+        }
+
+        /* Footer Specific Styles */
+.footer-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 90%;
+  max-width: 1000px;
+  background-color: #ffffff;
+  padding: 20px;
+  box-sizing: border-box;
+  margin: 40px auto;
+}
+
+.footer-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  width: 100%;
+}
+
+.footer-left,
+.footer-right {
+  flex: 1;
+  max-width: 600px;
+  padding-right: 20px;
+  box-sizing: border-box;
+}
+
+.logo-and-title {
+  display: flex;
+  align-items: center; /* Align items vertically */
+}
+
+.logo-and-title img {
+  width: 50px; /* Adjust the width as needed */
+  height: auto; /* Maintain aspect ratio */
+  margin-right: 10px; /* Adjust the margin as needed */
+  margin-top: -15px;
+}
+
+.footer-right {
+  margin-top: 6%;
+}
+
+.footer-title {
+  font-size: 2em;
+  margin-bottom: 20px;
+}
+
+.footer-description {
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  margin-bottom: 20px;
+}
+
+.footer-icons {
+  display: flex;
+  align-items: center; /* Align items vertically in the center */
+}
+
+.footer-icons a {
+  margin-right: 10px;
+  color: black;
+}
+
+.footer-links {
+  list-style: none;
+  padding: 0;
+  padding-left: 100px; /* Add right padding to move the links towards the right */
+}
+
+.footer-links li {
+  margin-bottom: 10px;
+  position: relative; /* To position the pseudo-element */
+}
+
+.footer-links a {
+  color: black;
+  text-decoration: underline;
+  font-size: 1em;
+  padding-left: 30px; /* Increased padding to make space for the larger arrow */
+  position: relative; /* Position relative for absolute positioning of arrow */
+}
+
+.footer-links a::before {
+  content: '→'; /* Unicode for right arrow */
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%); /* Center the arrow vertically */
+  color: black;
+  font-size: 1.5em; /* Increase the font size to make the arrow larger */
+  height: 1.5em; /* Set the height of the arrow */
+  width: 1.5em; /* Set the width of the arrow */
+}
+
+.footer-bottom {
+  text-align: center;
+  margin-top: 20px;
+  font-size: 0.875em;
+  width: 100%;
+}
+
+.footer-bottom a {
+  color: black;
+  font-weight: bold;
+}
+footer {
+  position: relative;
+  padding: 50px 0;
+}
+@media (max-width: 670px) {
+  .footer-content {
+      flex-direction: column;
+      text-align: center;
+  }
+
+  .footer-left, .footer-right {
+      min-width: 100%;
+  }
+
+  .footer-right {
+      margin-top: 20px;
+  }
+
+  .footer-icons {
+      display: flex;
+      justify-content: center;
+      width: 100%;
+      gap: 20px;
+  }
+
+  .footer-links {
+      align-items: center;
+      text-align: center;
+      padding: 0px;
+  }
+}
+
+@media (max-width: 400px) {
+
+  .footer-description {
+      text-align: center;
+  }
+
+  .footer-links {
+      align-items: center;
+      text-align: start;
+  }
+}
+
+/* Back-to-top */
+#back-to-top-container {
+  position: fixed;
+  bottom: 30px;
+  right: 30px; 
+  cursor: pointer;
+  z-index: 1000;
+}
+
+.hov:hover{
+  color: rgba(58, 113, 224, 0.755);
+}
+
+#back-to-top-container {
+  position: fixed;
+  bottom: 30px;
+  right: 30px; 
+  cursor: pointer;
+  z-index: 1000;
+}
+
+.circle1 {
+  background-color: #fff;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: background-color 0.3s;
+}
+
+#back-to-top {
+  width: 40px; 
+  height: 40px; 
+  fill:  currentColor;
+  transition: fill 0.3s;
+}
+#back-to-top:hover{
+  fill: rgba(58, 55, 55);
+}
+
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <h1>Licensing</h1>
+        <p>Welcome to ResourceHub, This project is licensed under the MIT License. This page outlines the terms of the license and provides details on how you can use, modify and distribute our project.</p>
+        <h2>MIT License</h2>
+        <p>Copyright (c) 2023 Joseph Martin</p>
+        <p>Permission is hereby granted, free of charge, to any person obtaining a copy<br>
+            of this software and associated documentation files (the "Software"), to deal<br>
+            in the Software without restriction, including without limitation the rights<br>
+            to use, copy, modify, merge, publish, distribute, sublicense, and/or sell<br>
+            copies of the Software, and to permit persons to whom the Software is<br>
+            furnished to do so, subject to the following conditions:</p>
+        <p>The above copyright notice and this permission notice shall be included in all<br>
+            copies or substantial portions of the Software.</p>
+        <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR<br>
+            IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,<br>
+            FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE<br>
+            AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER<br>
+            LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,<br>
+            OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE<br>
+            SOFTWARE.</p>
+    </div>
+
+    <!-- Footer Section -->
+    <div class="footer-container">
+        <div class="flex flex-col footer-content md:flex-row">
+            <div class="footer-left">
+                <div class="logo-and-title">
+                    <img id="logo-image" src="assets/footerLight.png" alt="ResourceHub Image">
+                    <h2 class="footer-title">ResourceHub</h2>
+                </div>
+                <p class="footer-description">ResourceHub is an open-source project that serves as a one-stop repository
+                    of
+                    valuable resources curated by the amazing contributors in the community</p>
+                <div class="footer-icons">
+                    <a href="https://github.com/jfmartinz/ResourceHub" target="_blank" aria-label="Github">
+                        <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                            <path fill="black"
+                                d="M12 0a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2.1c-3.4.7-4.1-1.6-4.1-1.6-.5-1.2-1.3-1.6-1.3-1.6-1.1-.8.1-.8.1-.8 1.2.1 1.8 1.3 1.8 1.3 1 .2 1.7.7 2 .9.2-.7.4-1.3.7-1.6-2.7-.3-5.5-1.3-5.5-5.6 0-1.3.4-2.3 1.2-3.2-.1-.3-.5-1.4.1-3 0 0 1-.3 3.4 1.2a11.4 11.4 0 0 1 6.2 0c2.4-1.5 3.4-1.2 3.4-1.2.6 1.6.2 2.7.1 3 .8.9 1.2 1.9 1.2 3.2 0 4.3-2.8 5.3-5.5 5.6.4.4.7 1.1.7 2.1v3c0 .3.2.7.8.6A12 12 0 0 0 12 0Z" />
+                        </svg>
+                    </a>
+                    <a href="https://discord.com/channels/1243120700626309131/1243121246217175081" target="_blank"
+                        aria-label="Discord">
+                        <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                            <path fill="black"
+                                d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2763-3.68-.2763-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561 19.911 19.911 0 004.967 2.5225.0777.0777 0 00.0842-.0276c.3841-.5234.7217-1.0782 1.0062-1.657a.076.0766 0 00-.0416-.1057 13.1141 13.1141 0 01-1.872-1.0279.077.077 0 01-.0076-.1257c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.0991.246.1981.3728.2924a.077.077 0 01-.0066.1256 12.7578 12.7578 0 01-1.873 1.0279.0766.0766 0 00-.0407.1067c.2845.5788.6221 1.1336 1.0062 1.657a.076.076 0 00.0842.0276 19.9183 19.9183 0 004.967-2.5225.077.077 0 00.0313-.0561c.5004-5.177-.8382-9.6739-3.5485-13.6607a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.955-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.955 2.4189-2.1568 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.955-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z" />
+                        </svg>
+                    </a>
+                </div>
+            </div>
+            <div class="footer-right">
+                <ul class="footer-links">
+                    <li><a href="https://github.com/jfmartinz/ResourceHub" target="_blank" class="hov">View on
+                            GitHub</a></li>
+                    <li><a href="https://github.com/jfmartinz/ResourceHub/stargazers" target="_blank" class="hov">Star
+                            on GitHub</a></li>
+                    <li><a href="https://github.com/jfmartinz/ResourceHub/blob/main/CONTRIBUTING.md" target="_blank"
+                            class="hov">How to Contribute</a></li>
+                    <li><a href="https://github.com/jfmartinz/ResourceHub/edit/main/README.md" target="_blank"
+                            class="hov">Edit on GitHub</a></li>
+                    <li><a href="feedback.html" class="hov">Feedback</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>Copyright &copy; 2024 <a href="#">ResourceHub</a>. All Rights Reserved.</p>
+        </div>
+        <div id="back-to-top-container">
+            <div class="circle1">
+                <svg id="back-to-top" xmlns="http://www.w3.org/2000/svg" width="48" height="48" fill="currentColor"
+                    class="bi bi-arrow-up-circle-fill" viewBox="0 0 16 16">
+                    <path
+                        d="M16 8A8 8 0 1 0 0 8a8 8 0 0 0 16 0m-7.5 3.5a.5.5 0 0 1-1 0V5.707L5.354 7.854a.5.5 0 1 1-.708-.708l3-3a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 5.707z" />
+                </svg>
+            </div>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/new-website/Licensing.html
+++ b/new-website/Licensing.html
@@ -2,317 +2,92 @@
 <html lang="en">
 
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="assets/logo.png">
-    <title>License</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="assets/logo.png">
+  <title>License</title>
 
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            background-color: #fff;
-            margin: 0;
-            padding: 0;
-        }
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #fff;
+      margin: 0;
+      padding: 0;
+    }
 
-        .container {
-            max-width: 800px;
-            margin: 30px auto;
-            padding: 20px;
-            background-color: #fff;
-            /* box-shadow: 0 0 10px rgba(0, 0, 0, 0.1); */
-            border-radius: 5px;
-        }
+    .container {
+      max-width: 800px;
+      margin: 30px auto;
+      background-color: #fff;
+      /* box-shadow: 0 0 10px rgba(0, 0, 0, 0.1); */
+      border-radius: 5px;
+    }
 
-        h1 {
-            /* text-align: center; */
-            font-size: 2em;
-            color: #333;
-            margin-bottom: 20px;
-        }
+    h1 {
+      /* text-align: center; */
+      font-size: 2em;
+      color: #333;
+      margin-bottom: 20px;
+    }
 
-        p {
-            font-size: 1.1em;
-            color: #555;
-            line-height: 1.6;
-        }
+    p {
+      font-size: 1.1em;
+      color: #555;
+      line-height: 1.6;
+    }
 
-        p+p {
-            margin-top: 20px;
-        }
-
-        /* Footer Specific Styles */
-.footer-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 90%;
-  max-width: 1000px;
-  background-color: #ffffff;
-  padding: 20px;
-  box-sizing: border-box;
-  margin: 40px auto;
-}
-
-.footer-content {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  width: 100%;
-}
-
-.footer-left,
-.footer-right {
-  flex: 1;
-  max-width: 600px;
-  padding-right: 20px;
-  box-sizing: border-box;
-}
-
-.logo-and-title {
-  display: flex;
-  align-items: center; /* Align items vertically */
-}
-
-.logo-and-title img {
-  width: 50px; /* Adjust the width as needed */
-  height: auto; /* Maintain aspect ratio */
-  margin-right: 10px; /* Adjust the margin as needed */
-  margin-top: -15px;
-}
-
-.footer-right {
-  margin-top: 6%;
-}
-
-.footer-title {
-  font-size: 2em;
-  margin-bottom: 20px;
-}
-
-.footer-description {
-  font-size: 1em;
-  line-height: 1.5;
-  color: #333333;
-  margin-bottom: 20px;
-}
-
-.footer-icons {
-  display: flex;
-  align-items: center; /* Align items vertically in the center */
-}
-
-.footer-icons a {
-  margin-right: 10px;
-  color: black;
-}
-
-.footer-links {
-  list-style: none;
-  padding: 0;
-  padding-left: 100px; /* Add right padding to move the links towards the right */
-}
-
-.footer-links li {
-  margin-bottom: 10px;
-  position: relative; /* To position the pseudo-element */
-}
-
-.footer-links a {
-  color: black;
-  text-decoration: underline;
-  font-size: 1em;
-  padding-left: 30px; /* Increased padding to make space for the larger arrow */
-  position: relative; /* Position relative for absolute positioning of arrow */
-}
-
-.footer-links a::before {
-  content: '→'; /* Unicode for right arrow */
-  position: absolute;
-  left: 0;
-  top: 50%;
-  transform: translateY(-50%); /* Center the arrow vertically */
-  color: black;
-  font-size: 1.5em; /* Increase the font size to make the arrow larger */
-  height: 1.5em; /* Set the height of the arrow */
-  width: 1.5em; /* Set the width of the arrow */
-}
-
-.footer-bottom {
-  text-align: center;
-  margin-top: 20px;
-  font-size: 0.875em;
-  width: 100%;
-}
-
-.footer-bottom a {
-  color: black;
-  font-weight: bold;
-}
-footer {
-  position: relative;
-  padding: 50px 0;
-}
-@media (max-width: 670px) {
-  .footer-content {
-      flex-direction: column;
-      text-align: center;
-  }
-
-  .footer-left, .footer-right {
-      min-width: 100%;
-  }
-
-  .footer-right {
+    p+p {
       margin-top: 20px;
-  }
-
-  .footer-icons {
+    }
+    header{
       display: flex;
-      justify-content: center;
-      width: 100%;
-      gap: 20px;
-  }
+    justify-content: center;
+    align-items: center;
+    }
+    header h1 {
+      color: black;
+      font-size: 40px;
+      margin-left: 4px;
+    }
+    header img {
+      width: 50px;
+      height: 50px;
+    }
+    header a {
+      text-decoration: none;
+    }
 
-  .footer-links {
-      align-items: center;
-      text-align: center;
-      padding: 0px;
-  }
-}
-
-@media (max-width: 400px) {
-
-  .footer-description {
-      text-align: center;
-  }
-
-  .footer-links {
-      align-items: center;
-      text-align: start;
-  }
-}
-
-/* Back-to-top */
-#back-to-top-container {
-  position: fixed;
-  bottom: 30px;
-  right: 30px; 
-  cursor: pointer;
-  z-index: 1000;
-}
-
-.hov:hover{
-  color: rgba(58, 113, 224, 0.755);
-}
-
-#back-to-top-container {
-  position: fixed;
-  bottom: 30px;
-  right: 30px; 
-  cursor: pointer;
-  z-index: 1000;
-}
-
-.circle1 {
-  background-color: #fff;
-  border-radius: 50%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  transition: background-color 0.3s;
-}
-
-#back-to-top {
-  width: 40px; 
-  height: 40px; 
-  fill:  currentColor;
-  transition: fill 0.3s;
-}
-#back-to-top:hover{
-  fill: rgba(58, 55, 55);
-}
-
-    </style>
+  </style>
 </head>
 
 <body>
-    <div class="container">
-        <h1>Licensing</h1>
-        <p>Welcome to ResourceHub, This project is licensed under the MIT License. This page outlines the terms of the license and provides details on how you can use, modify and distribute our project.</p>
-        <h2>MIT License</h2>
-        <p>Copyright (c) 2023 Joseph Martin</p>
-        <p>Permission is hereby granted, free of charge, to any person obtaining a copy<br>
-            of this software and associated documentation files (the "Software"), to deal<br>
-            in the Software without restriction, including without limitation the rights<br>
-            to use, copy, modify, merge, publish, distribute, sublicense, and/or sell<br>
-            copies of the Software, and to permit persons to whom the Software is<br>
-            furnished to do so, subject to the following conditions:</p>
-        <p>The above copyright notice and this permission notice shall be included in all<br>
-            copies or substantial portions of the Software.</p>
-        <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR<br>
-            IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,<br>
-            FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE<br>
-            AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER<br>
-            LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,<br>
-            OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE<br>
-            SOFTWARE.</p>
-    </div>
-
-    <!-- Footer Section -->
-    <div class="footer-container">
-        <div class="flex flex-col footer-content md:flex-row">
-            <div class="footer-left">
-                <div class="logo-and-title">
-                    <img id="logo-image" src="assets/footerLight.png" alt="ResourceHub Image">
-                    <h2 class="footer-title">ResourceHub</h2>
-                </div>
-                <p class="footer-description">ResourceHub is an open-source project that serves as a one-stop repository
-                    of
-                    valuable resources curated by the amazing contributors in the community</p>
-                <div class="footer-icons">
-                    <a href="https://github.com/jfmartinz/ResourceHub" target="_blank" aria-label="Github">
-                        <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                            <path fill="black"
-                                d="M12 0a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2.1c-3.4.7-4.1-1.6-4.1-1.6-.5-1.2-1.3-1.6-1.3-1.6-1.1-.8.1-.8.1-.8 1.2.1 1.8 1.3 1.8 1.3 1 .2 1.7.7 2 .9.2-.7.4-1.3.7-1.6-2.7-.3-5.5-1.3-5.5-5.6 0-1.3.4-2.3 1.2-3.2-.1-.3-.5-1.4.1-3 0 0 1-.3 3.4 1.2a11.4 11.4 0 0 1 6.2 0c2.4-1.5 3.4-1.2 3.4-1.2.6 1.6.2 2.7.1 3 .8.9 1.2 1.9 1.2 3.2 0 4.3-2.8 5.3-5.5 5.6.4.4.7 1.1.7 2.1v3c0 .3.2.7.8.6A12 12 0 0 0 12 0Z" />
-                        </svg>
-                    </a>
-                    <a href="https://discord.com/channels/1243120700626309131/1243121246217175081" target="_blank"
-                        aria-label="Discord">
-                        <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                            <path fill="black"
-                                d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2763-3.68-.2763-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561 19.911 19.911 0 004.967 2.5225.0777.0777 0 00.0842-.0276c.3841-.5234.7217-1.0782 1.0062-1.657a.076.0766 0 00-.0416-.1057 13.1141 13.1141 0 01-1.872-1.0279.077.077 0 01-.0076-.1257c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.0991.246.1981.3728.2924a.077.077 0 01-.0066.1256 12.7578 12.7578 0 01-1.873 1.0279.0766.0766 0 00-.0407.1067c.2845.5788.6221 1.1336 1.0062 1.657a.076.076 0 00.0842.0276 19.9183 19.9183 0 004.967-2.5225.077.077 0 00.0313-.0561c.5004-5.177-.8382-9.6739-3.5485-13.6607a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.955-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.955 2.4189-2.1568 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.955-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z" />
-                        </svg>
-                    </a>
-                </div>
-            </div>
-            <div class="footer-right">
-                <ul class="footer-links">
-                    <li><a href="https://github.com/jfmartinz/ResourceHub" target="_blank" class="hov">View on
-                            GitHub</a></li>
-                    <li><a href="https://github.com/jfmartinz/ResourceHub/stargazers" target="_blank" class="hov">Star
-                            on GitHub</a></li>
-                    <li><a href="https://github.com/jfmartinz/ResourceHub/blob/main/CONTRIBUTING.md" target="_blank"
-                            class="hov">How to Contribute</a></li>
-                    <li><a href="https://github.com/jfmartinz/ResourceHub/edit/main/README.md" target="_blank"
-                            class="hov">Edit on GitHub</a></li>
-                    <li><a href="feedback.html" class="hov">Feedback</a></li>
-                </ul>
-            </div>
-        </div>
-        <div class="footer-bottom">
-            <p>Copyright &copy; 2024 <a href="#">ResourceHub</a>. All Rights Reserved.</p>
-        </div>
-        <div id="back-to-top-container">
-            <div class="circle1">
-                <svg id="back-to-top" xmlns="http://www.w3.org/2000/svg" width="48" height="48" fill="currentColor"
-                    class="bi bi-arrow-up-circle-fill" viewBox="0 0 16 16">
-                    <path
-                        d="M16 8A8 8 0 1 0 0 8a8 8 0 0 0 16 0m-7.5 3.5a.5.5 0 0 1-1 0V5.707L5.354 7.854a.5.5 0 1 1-.708-.708l3-3a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 5.707z" />
-                </svg>
-            </div>
-        </div>
-    </div>
+  <header>
+    <a href="index.html"><img id="logo-image" src="assets/footerLight.png" alt="ResourceHub Image"></a>
+    <a href="index.html"><h1>ResourceHub</h1> </a>
+  </header>
+  <div class="container">
+    <h1>Licensing</h1>
+    <p>Welcome to ResourceHub, This project is licensed under the MIT License. This page outlines the terms of the
+      license and provides details on how you can use, modify and distribute our project.</p>
+    <h2>MIT License</h2>
+    <p>Copyright (c) 2023 Joseph Martin</p>
+    <p>Permission is hereby granted, free of charge, to any person obtaining a copy<br>
+      of this software and associated documentation files (the "Software"), to deal<br>
+      in the Software without restriction, including without limitation the rights<br>
+      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell<br>
+      copies of the Software, and to permit persons to whom the Software is<br>
+      furnished to do so, subject to the following conditions:</p>
+    <p>The above copyright notice and this permission notice shall be included in all<br>
+      copies or substantial portions of the Software.</p>
+    <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR<br>
+      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,<br>
+      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE<br>
+      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER<br>
+      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,<br>
+      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE<br>
+      SOFTWARE.</p>
+  </div>
+  </div>
 </body>
 
 </html>

--- a/new-website/index.html
+++ b/new-website/index.html
@@ -271,7 +271,7 @@
             </div>
             <p class="license-description">
                 <span>ResourceHub is licensed under the MIT License - see</span><br> the
-                <a href="Licensing.html" target="_blank">LICENSE</a> file for details.
+                <a href="Licensing.html" >LICENSE</a> file for details.
             </p>
         </div>
     </div>

--- a/new-website/index.html
+++ b/new-website/index.html
@@ -271,7 +271,7 @@
             </div>
             <p class="license-description">
                 <span>ResourceHub is licensed under the MIT License - see</span><br> the
-                <a href="LICENSE" target="_blank">LICENSE</a> file for details.
+                <a href="Licensing.html" target="_blank">LICENSE</a> file for details.
             </p>
         </div>
     </div>


### PR DESCRIPTION
Hey @jfmartinz 
issue closes #1377 

## What Changes I Made - 
- I have **added a dedicated "Licensing Page"** that reflects the use of the MIT License. 
- **Added Accessible link** to the license section in home page.
- Integrated Footer.
- Integrated Scroll to top button.
- also **Added a Favicon** to the page.

https://github.com/jfmartinz/ResourceHub/assets/131389695/586ef1c1-b422-485c-8001-e846bcd1e80a


## Type of change
- [x] Website enhancement or fixes

## Checklist:
- [x] I read carefully [CONTRIBUTING.md](https://github.com/jfmartinz/ResourceHub/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas


Please take a look and review it.