### PR TITLE
Resolved Light-mode persist issue

### DIFF
--- a/new-website/index.html
+++ b/new-website/index.html
@@ -411,6 +411,28 @@
             });
         </script>
         <script src="cursorAnimation.js"></script>
+
+        <script>
+            // Check the dark mode preference on page load
+            document.addEventListener('DOMContentLoaded', () => {
+                const darkMode = localStorage.getItem('darkMode');
+                if (darkMode === 'enabled') {
+                    document.body.classList.add('dark');
+                }
+            });
+        
+            // Function to toggle dark mode
+            function toggleDarkMode() {
+                const body = document.body;
+                if (body.classList.contains('dark')) {
+                    body.classList.remove('dark');
+                    localStorage.setItem('darkMode', 'disabled');
+                } else {
+                    body.classList.add('dark');
+                    localStorage.setItem('darkMode', 'enabled');
+                }
+            }
+        </script>
 </body>
 
 </html>


### PR DESCRIPTION
Hey @jfmartinz ,
issue closes #1156 
I have resolved the issue to persist the dark mode preference across page refreshes using localStorage.
The changes ensure that the user's selected mode (dark or light) is maintained even after the page is refreshed.

Changes made are as follows :

Added functionality to check "localStorage" for the user's dark mode preference upon page load and set the initial state accordingly.
Updated the event listener for the toggle switch to save the dark mode preference in localStorage whenever the user changes the mode.
Now, Whenever user will refresh or log in the page again, The selected mode preference will be the same as chosen.

Please take a look and review it.
Also, please add the labels.